### PR TITLE
Feature Gate: deactivate canceled partitioned epoch reward

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -253,7 +253,8 @@ pub fn create_program_runtime_environment_v1<'a>(
     let curve25519_syscall_enabled = feature_set.is_active(&curve25519_syscall_enabled::id());
     let disable_fees_sysvar = feature_set.is_active(&disable_fees_sysvar::id());
     let epoch_rewards_syscall_enabled =
-        feature_set.is_active(&enable_partitioned_epoch_reward::id());
+        feature_set.is_active(&enable_partitioned_epoch_reward::id())
+        && !feature_set.is_active(&feature_set::deactivate_canceled_partitioned_epoch_reward::id());
     let disable_deploy_of_alloc_free_syscall = reject_deployment_of_broken_elfs
         && feature_set.is_active(&disable_deploy_of_alloc_free_syscall::id());
     let last_restart_slot_syscall_enabled = feature_set.is_active(&last_restart_slot_sysvar::id());

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1123,6 +1123,9 @@ impl Bank {
     fn is_partitioned_rewards_feature_enabled(&self) -> bool {
         self.feature_set
             .is_active(&feature_set::enable_partitioned_epoch_reward::id())
+            && !self
+                .feature_set
+                .is_active(&feature_set::deactivate_canceled_partitioned_epoch_reward::id())
     }
 
     pub(crate) fn set_epoch_reward_status_active(

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -784,6 +784,10 @@ pub mod enable_native_mint_wrap_account {
     solana_sdk::declare_id!("BeCY6VL4CKQR2QUwe9w3iRtNMN91FMW1sXbRzwfc3WYc");
 }
 
+pub mod deactivate_canceled_partitioned_epoch_reward {
+    solana_sdk::declare_id!("3sioPumDoSRarqzp442ETGUvTCLADgU9eFzKJj375B23");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -975,6 +979,7 @@ lazy_static! {
         (remove_rounding_in_fee_calculation::id(), "Removing unwanted rounding in fee calculation #34982"),
         (deprecate_unused_legacy_vote_plumbing::id(), "Deprecate unused legacy vote tx plumbing"),
         (enable_native_mint_wrap_account::id(), "enable the native mint wrap account"),
+        (deactivate_canceled_partitioned_epoch_reward::id(), "deactivate canceled partitioned epoch reward"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
This feature was canceled and replaced on Solana mainnet.
It prevents the migration to v2.0.
